### PR TITLE
Bug: OSC8 hyperlink containing ANSI color sequence

### DIFF
--- a/examples/colored-hyperlink.sh
+++ b/examples/colored-hyperlink.sh
@@ -1,0 +1,1 @@
+printf '\e]8;;https://github.com/alacritty\e\\\e[36mAla\e[2mcri\e[0mtty\e]8;;\e\\\n'


### PR DESCRIPTION
Hi @tizee, I wanted to mention to you a bug that's present in your OSC8 tmux branch. I'm sorry for abusing the Pull Request like this, but I wasn't sure what would be a better way to communicate this. So I'm not expecting you to merge this PR! Just wanted to point out that the hyperlink does not extend to the end of the text correctly:

```
printf '\e]8;;https://github.com/alacritty\e\\\e[36mAla\e[2mcri\e[0mtty\e]8;;\e\\\n'
```

<img width="438" alt="image" src="https://user-images.githubusercontent.com/52205/191772599-a12c95e6-b97a-4976-9e21-aea83153607e.png">


Thanks for working on this! When the time comes to raise the issue with the tmux author again, I think it will help to list (popular) applications making good use of OSC8 hyperlinks. Some ones that I can currently think of (I'm sure there are more) are

- GNU ls (`--hyperlink`)
- https://github.com/nushell/nushell
- https://github.com/dandavison/delta (I am the author of it)
- https://github.com/Textualize/rich

Are some compiler projects using them?